### PR TITLE
Configure NBF delay via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,23 @@ $ cp vendor/laravel/lumen-framework/config/auth.php config/
 ```text
 # edit: .env
 
+# required fields
 JWT_KEY=XXXXXXXXXXXXXXXXXXXXX
 JWT_EXPIRE_AFTER=7200
 JWT_ISSUER=myappname-or-domain
+
+# optional fields
 JWT_INCLUDE=id,email,avatar,full_name,first_name,last_name
+JWT_NBF_DELAY=5
 
 ```
+
+`JWT_INCLUDE` lists the user properties to include in the `data` property of the
+token. Defaults to `id`.
+
+`JWT_NBF_DELAY` is the number of seconds after generation at which the token
+becomes valid (that is, the token is *n*ot valid *b*e*f*ore now + delay).
+Defaults to `10`.
 
 ## Use (server side): Lumen
 

--- a/src/JWTHelper.php
+++ b/src/JWTHelper.php
@@ -47,6 +47,12 @@ class JWTHelper
      */
     protected $issuer;
 
+    /**
+     * Delay in seconds before token will be valid
+     * @var integer
+     */
+    protected $notBefore_delay;
+
 
     /**
      * Create a new helper.
@@ -68,6 +74,8 @@ class JWTHelper
       // if (is_null($includes)) throw new \RuntimeException("Please set 'JWT_INCLUDES' in Lumen env file. Ex: id,email,phone");
       $this->includes = is_null($includes) ? ['id'] : explode(",", $includes);
       if (!in_array('id', $this->includes)) $this->includes[] = 'id'; // always add user id
+
+      $this->notBefore_delay = env('JWT_NBF_DELAY', 10);
     }
 
     /**
@@ -128,7 +136,7 @@ class JWTHelper
 
       $tokenId = md5(uniqid($user->email, true));
       $issuedAt   = time();
-      $notBefore  = $issuedAt + 10;  //Adding 10 seconds
+      $notBefore  = $issuedAt + $this->notBefore_delay;
       $expire     = $notBefore + $this->expire_after;
       $jwt_key = $this->key;
       $issuer = $this->issuer;


### PR DESCRIPTION
Resolves #1:
* Allows the delay in the token's `nbf` parameter to be configured via an optional `JWT_NBF_DELAY` key in the `.env` file. If the value is not given then it defaults to 10 seconds, so that the behaviour of existing installations will not be affected.
* Provides a minimal update to the README describing the parameter.
