### PR TITLE
Allow the name of the account id field to be configured via .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bootstrap/cache/
 
 # Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
 .rocketeer/
+
+# Editor / IDE files
+.vscode/

--- a/README.md
+++ b/README.md
@@ -78,13 +78,18 @@ JWT_EXPIRE_AFTER=7200
 JWT_ISSUER=myappname-or-domain
 
 # optional fields
-JWT_INCLUDE=id,email,avatar,full_name,first_name,last_name
+JWT_ID_FIELD=user_id
+JWT_INCLUDE=email,avatar,full_name,first_name,last_name
 JWT_NBF_DELAY=5
 
 ```
 
+`JWT_ID_FIELD` is the name of the property on the user model that the
+Laravel authentication provider uses to look up accounts. Defaults to `id`.
+
 `JWT_INCLUDE` lists the user properties to include in the `data` property of the
-token. Defaults to `id`.
+token. If the `JWT_ID_FIELD` is not part of this list, it will be automatically
+added. Defaults to the id field.
 
 `JWT_NBF_DELAY` is the number of seconds after generation at which the token
 becomes valid (that is, the token is *n*ot valid *b*e*f*ore now + delay).

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -87,7 +87,7 @@ class JWTGuard implements Guard
         $user = null;
 
         if ($this->jwt->isHealthy()) {
-            $id = $this->jwt->getPayload()->id;
+            $id = $this->jwt->getId();
             $user = $this->provider->retrieveById($id);
         }
 

--- a/src/JWTHelper.php
+++ b/src/JWTHelper.php
@@ -178,6 +178,18 @@ class JWTHelper
     }
 
     /**
+     * Get value stored in token id field
+     * @return string
+     */
+    public function getId()
+    {
+      $payload = $this->getPayload();
+      return !is_null($payload)
+                ? $payload->{$this->id_field}
+                : null;
+    }
+
+    /**
      * Refresh token
      * @return string New Token
      */

--- a/src/JWTHelper.php
+++ b/src/JWTHelper.php
@@ -35,8 +35,13 @@ class JWTHelper
     protected $includes;
 
     /**
+     * JWT payload property to use when looking up users by primary key.
+     * @var string
+     */
+    protected $id_field;
+
+    /**
      * Expire (in seconds)
-     *
      * @var string
      */
     protected $expire_after;
@@ -70,10 +75,14 @@ class JWTHelper
       $this->issuer = env('JWT_ISSUER');
       if (is_null($this->issuer)) throw new \RuntimeException("Please set 'JWT_ISSUER' in Lumen env file.");
 
+      $this->id_field = env('JWT_ID_FIELD');
+      if (is_null($this->id_field)) {
+        $this->id_field = 'id';
+      }
+
       $includes = env('JWT_INCLUDE');
-      // if (is_null($includes)) throw new \RuntimeException("Please set 'JWT_INCLUDES' in Lumen env file. Ex: id,email,phone");
-      $this->includes = is_null($includes) ? ['id'] : explode(",", $includes);
-      if (!in_array('id', $this->includes)) $this->includes[] = 'id'; // always add user id
+      $this->includes = is_null($includes) ? [$this->id_field] : explode(",", $includes);
+      if (!in_array($this->id_field, $this->includes)) $this->includes[] = $this->id_field; // always add user id
 
       $this->notBefore_delay = env('JWT_NBF_DELAY', 10);
     }


### PR DESCRIPTION
A user provider that looks up accounts via a field other than `id` can now be used, by supplying a custom value for the new key `JWT_ID_FIELD` in the .env file. This field is always included in the resulting token and defaults to `"id"` when not specified.